### PR TITLE
Feature/6 packagelist parser

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ fn main() {
     let dryrun = args.is_present("dryrun");
 
     print_section_separator();
-    let sys = systemconfig::read_system_config(platform, distro).unwrap();
+    let sys = match systemconfig::read_system_config(platform, distro) {
+        Ok(cfg) => cfg,
+        Err(e) => panic!("Error: {}", e),
+    };
     println!(
         "System Configuration:\nName: {} | install_cmd: {}",
         sys.name.unwrap_or("default".to_string()),
@@ -42,8 +45,12 @@ fn main() {
         // continue?
     }
 
-    let packageconfig = packageconfig::PackageConfig::new()
-        .expect("Error opening packages.toml file. Check output for details.");
+    let packageconfig = match packageconfig::PackageConfig::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            panic!("Error loading packages config: {}", e);
+        }
+    };
 
     let targ_def: Vec<&str> = target.split(".").collect();
     let target_internal = match targ_def.len() {

--- a/src/packageconfig.rs
+++ b/src/packageconfig.rs
@@ -1,3 +1,15 @@
+pub enum Source {
+    Git,
+    Web, // Straight download, e.g. via curl
+    Local,
+}
+
+pub enum Status {
+    Ready,
+    Succeeded,
+    Failed,
+}
+
 pub struct Package {
     name: String,
     status: Status,

--- a/src/packageconfig.rs
+++ b/src/packageconfig.rs
@@ -1,5 +1,8 @@
 pub struct Package {
-    // todo
+    name: String,
+    status: Status,
+    source: Option<Source>,
+    cmd: Option<Vec<String>>
 }
 
 pub struct Target {

--- a/src/packageconfig.rs
+++ b/src/packageconfig.rs
@@ -1,27 +1,228 @@
+use std::fmt::Display;
+
+use crate::tomlhelper;
+use toml::Value;
+
+const PACKAGES_IDX: &str = "packages";
+const PACKAGECONFIG_IDX: &str = "packagedefinition";
+const SOURCE_TYPE_IDX: &str = "source";
+const SOURCE_URL_IDX: &str = "url";
+const CMDS_IDX: &str = "install_cmds";
+
+#[derive(Debug)]
 pub enum Source {
     Git,
     Web, // Straight download, e.g. via curl
     Local,
 }
 
+#[allow(dead_code)]
+#[derive(Debug)]
 pub enum Status {
+    ParseErr,
     Ready,
     Succeeded,
     Failed,
 }
 
+pub struct PackageConfig {
+    toml: Value,
+    packageconfigs: Option<Value>,
+}
+
+#[derive(Debug)]
 pub struct Package {
-    name: String,
-    status: Status,
-    source: Option<Source>,
-    cmd: Option<Vec<String>>
+    pub name: String,
+    pub status: Status,
+    pub source: Option<(Source, String)>,
+    pub cmd: Option<Vec<String>>,
 }
 
 pub struct Target {
-    name: String,
-    host: Option<String>,
+    pub name: String,
+    pub host: Option<String>,
 }
 
-pub fn read_package_list(target: Target) -> Result<Vec<Package>, ()> {
-    Err(())
+impl PackageConfig {
+    pub fn new() -> Result<PackageConfig, ()> {
+        match tomlhelper::open_toml() {
+            Ok(t) => {
+                let packagesconfig = t.get(PACKAGECONFIG_IDX).map(|v| v.clone());
+                Ok(PackageConfig {
+                    toml: t,
+                    packageconfigs: packagesconfig,
+                })
+            }
+            Err(_) => Err(()),
+        }
+    }
+
+    pub fn read_package_list(&self, target: Target) -> Vec<Package> {
+        let mut packages: Vec<Package> = Vec::new();
+        let packages_raw = self.read_packages(&target);
+        for packname in &packages_raw {
+            let pack = self.make_package(packname);
+            packages.push(pack);
+        }
+        packages
+    }
+
+    fn read_packages(&self, target: &Target) -> Vec<String> {
+        let mut packages: Vec<String> = Vec::new();
+        if let Some(main) = self.toml.get(&target.name) {
+            packages = self.get_packages_from_target(&main);
+            // try to get host specific packages if we have a hostname specified
+            if let Some(host) = &target.host {
+                if let Some(sub) = main.get(&host) {
+                    let mut sub_packages = self.get_packages_from_target(sub);
+                    packages.append(&mut sub_packages);
+                }
+            }
+        }
+        packages
+    }
+
+    fn get_packages_from_target(&self, root: &Value) -> Vec<String> {
+        let mut packages: Vec<String> = Vec::new();
+        if let Some(pack_toml) = root.get(PACKAGES_IDX) {
+            if pack_toml.is_array() {
+                for pack in pack_toml.as_array().unwrap() {
+                    if let Some(packstr) = pack.as_str() {
+                        packages.push(packstr.to_string());
+                    } else {
+                        println!("invalid package name: {}", pack);
+                    }
+                }
+            }
+        }
+        packages
+    }
+
+    fn make_package(&self, package: &str) -> Package {
+        if let Some(packageconfigs) = &self.packageconfigs {
+            if let Some(pack) = packageconfigs.get(package) {
+                let mut parse_ok = true;
+                let mut source: Option<(Source, String)> = None;
+                let source_type = pack.get(SOURCE_TYPE_IDX);
+                let source_url = pack.get(SOURCE_URL_IDX);
+                if source_type.is_some() && source_url.is_none()
+                    || source_type.is_none() && source_url.is_some()
+                {
+                    println!(
+                        "invalid package definition: source without url or url without sourcetype"
+                    ); // todo?
+                    parse_ok = false;
+                }
+                if source_type.is_some() && source_url.is_some() {
+                    if let Some(stype) = source_type.unwrap().as_str() {
+                        let stype_internal = Source::from_value(stype);
+                        let surl = source_url.unwrap().as_str();
+                        if stype_internal.is_ok() && surl.is_some() {
+                            source = Some((stype_internal.unwrap(), surl.unwrap().to_string()));
+                        }
+                    }
+                    if source.is_none() {
+                        parse_ok = false;
+                        println!("err reading source cfg");
+                    }
+                }
+                let mut cmds: Option<Vec<String>> = None;
+                if let Some(cmdsval) = pack.get(CMDS_IDX) {
+                    if let Some(cmdsarr) = cmdsval.as_array() {
+                        let mut cmdsvec: Vec<String> = Vec::new();
+                        for cmdval in cmdsarr {
+                            let cmd = cmdval.as_str();
+                            if cmd.is_some() {
+                                cmdsvec.push(cmd.unwrap().to_string());
+                            } else {
+                                parse_ok = false;
+                                println!("failed to read packagecmd: {}", cmdval);
+                            }
+                        }
+                        cmds = Some(cmdsvec);
+                    }
+                }
+                let status = match parse_ok {
+                    true => Status::Ready,
+                    false => Status::ParseErr,
+                };
+                return Package {
+                    name: package.to_string(),
+                    status: status,
+                    source: source,
+                    cmd: cmds,
+                };
+            } // detailed package
+        }
+        return Package {
+            name: package.to_string(),
+            status: Status::Ready,
+            source: None,
+            cmd: None,
+        }; // normal package without details
+    }
+}
+
+impl Source {
+    fn from_value(value: &str) -> Result<Source, ()> {
+        match value.to_lowercase().as_str() {
+            "git" => Ok(Source::Git),
+            "web" => Ok(Source::Web),
+            "local" => Ok(Source::Local),
+            _ => Err(()),
+        }
+    }
+
+    fn get_value(&self) -> &str {
+        match self {
+            Source::Git => "Git",
+            Source::Web => "Web",
+            Source::Local => "Local",
+        }
+    }
+}
+
+impl Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_value())
+    }
+}
+
+impl Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Status::Ready => "Status: Ready",
+            Status::ParseErr => "Status: Parse Error",
+            Status::Succeeded => "Status: Success",
+            Status::Failed => "Status: Failure",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl Display for Package {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Package '{}' [{}]", self.name, self.status)?;
+        let mut details: String = String::new();
+        if let Some(source) = &self.source {
+            details.push_str(&format!("Source: [Type: {}, Url: {}]", source.0, source.1));
+        }
+        if let Some(cmds) = &self.cmd {
+            if details.len() > 0 {
+                details.push_str(", ");
+            }
+            details.push_str("Cmds: [");
+            for (i, cmd) in cmds.iter().enumerate() {
+                details.push_str(&format!("'{}'", cmd));
+                if i + 1 < cmds.len() {
+                    details.push(',')
+                }
+            }
+            details.push_str("]")
+        }
+        if details.len() > 0 {
+            write!(f, "\n -> {}", details)?;
+        }
+        Ok(())
+    }
 }

--- a/src/packageconfig.rs
+++ b/src/packageconfig.rs
@@ -44,17 +44,14 @@ pub struct Target {
 }
 
 impl PackageConfig {
-    pub fn new() -> Result<PackageConfig, ()> {
-        match tomlhelper::open_toml() {
-            Ok(t) => {
-                let packagesconfig = t.get(PACKAGECONFIG_IDX).map(|v| v.clone());
-                Ok(PackageConfig {
-                    toml: t,
-                    packageconfigs: packagesconfig,
-                })
+    pub fn new() -> Result<PackageConfig, String> {
+        tomlhelper::open_toml().map(|t| {
+            let packagesconfig = t.get(PACKAGECONFIG_IDX).map(|v| v.clone());
+            PackageConfig {
+                toml: t,
+                packageconfigs: packagesconfig,
             }
-            Err(_) => Err(()),
-        }
+        })
     }
 
     pub fn read_package_list(&self, target: Target) -> Vec<Package> {

--- a/src/systemconfig.rs
+++ b/src/systemconfig.rs
@@ -38,10 +38,10 @@ impl SupportedSystems {
 pub fn read_system_config(
     platform: Option<&str>,
     distribution: Option<&str>,
-) -> Result<Systemconfig, ()> {
+) -> Result<Systemconfig, String> {
     if let Some(platform) = &platform {
         if !SupportedSystems::check_platform(&platform) {
-            return Err(());
+            return Err(format!("Platform {} not supported", platform));
         }
     }
 
@@ -68,7 +68,7 @@ pub fn read_system_config(
     }
 
     if install_cmd_toml.is_none() {
-        return Err(());
+        return Err("Missing install command".to_string());
     }
 
     let sysname = match distribution {

--- a/src/systemconfig.rs
+++ b/src/systemconfig.rs
@@ -1,4 +1,4 @@
-use toml::Value;
+use crate::tomlhelper;
 
 pub struct Systemconfig {
     pub name: Option<String>,
@@ -36,7 +36,6 @@ impl SupportedSystems {
 }
 
 pub fn read_system_config(
-    filename: &str,
     platform: Option<&str>,
     distribution: Option<&str>,
 ) -> Result<Systemconfig, ()> {
@@ -46,11 +45,7 @@ pub fn read_system_config(
         }
     }
 
-    let file = std::fs::read_to_string(filename).expect("Error reading config file");
-    let toml = match file.parse::<Value>() {
-        Ok(v) => v,
-        Err(_) => return Err(()),
-    };
+    let toml = tomlhelper::open_toml()?;
     let systemconfig = &toml["systemconfig"];
     let mut install_cmd_toml: Option<String> = None;
 

--- a/src/tomlhelper.rs
+++ b/src/tomlhelper.rs
@@ -2,10 +2,10 @@ use toml::Value;
 
 const PACKAGES: &str = "packages.toml";
 
-pub fn open_toml() -> Result<Value, ()> {
-    let file = std::fs::read_to_string(PACKAGES).expect("unable to read packages.toml");
+pub fn open_toml() -> Result<Value, String> {
+    let file = std::fs::read_to_string(PACKAGES).expect(&format!("unable to read {}", PACKAGES));
     match file.parse::<Value>() {
         Ok(v) => Ok(v),
-        Err(_) => Err(()),
+        Err(e) => Err(format!("Error during parse: {}", e)),
     }
 }

--- a/src/tomlhelper.rs
+++ b/src/tomlhelper.rs
@@ -1,0 +1,11 @@
+use toml::Value;
+
+const PACKAGES: &str = "packages.toml";
+
+pub fn open_toml() -> Result<Value, ()> {
+    let file = std::fs::read_to_string(PACKAGES).expect("unable to read packages.toml");
+    match file.parse::<Value>() {
+        Ok(v) => Ok(v),
+        Err(_) => Err(()),
+    }
+}


### PR DESCRIPTION
closes #6 

Implemented functionality to read packages from packages.toml on a specified target.
* combines the packages of the 'root' target with the specialized one if for example general.tower is specified  
* checks for custom packageconfigs in the packagedefinition section
* implements the interactive option to print the packagelist
* implements the display trait for packages and their enums to provide a readable println output

(!) Error handling is done via an additional status on the package: ParseError -> this would allow us to show a list of invalid packages and ask the user if those should be skipped or if he wants to fix the config before retrying.