### PR TITLE
#13: remove wrapping " from toml strings

### DIFF
--- a/src/systemconfig.rs
+++ b/src/systemconfig.rs
@@ -56,17 +56,17 @@ pub fn read_system_config(
     let mut install_cmd_toml: Option<String> = None;
 
     if let Some(val) = systemconfig.get("install_cmd") {
-        install_cmd_toml = Some(val.to_string());
+        install_cmd_toml = tomlhelper::extract_toml_str_val(val);
     }
     if let Some(target) = &platform {
         if let Some(specific_config) = systemconfig.get(target) {
             if let Some(val) = specific_config.get("install_cmd") {
-                install_cmd_toml = Some(val.to_string());
+                install_cmd_toml = tomlhelper::extract_toml_str_val(val);
             }
             if let Some(distro) = &distribution {
                 if let Some(distro_config) = specific_config.get(distro) {
                     if let Some(val) = distro_config.get("install_cmd") {
-                        install_cmd_toml = Some(val.to_string());
+                        install_cmd_toml = tomlhelper::extract_toml_str_val(val);
                     }
                 }
             }

--- a/src/tomlhelper.rs
+++ b/src/tomlhelper.rs
@@ -11,3 +11,17 @@ pub fn open_toml() -> Result<Value, Error> {
         Err(e) => Err(Error::with_msg(ErrorCode::ParseError, format!("{}", e))),
     }
 }
+
+pub fn extract_toml_str_val(val: &Value) -> Option<String> {
+    match val.as_str() {
+        Some(v) => {
+            if v.starts_with('\"') && v.ends_with('\"') {
+                // if the value is wrapped in ", remove them
+                Some(v[0..].to_owned())
+            } else {
+                Some(v.to_owned())
+            }
+        }
+        None => None,
+    }
+}


### PR DESCRIPTION
closes #13 

Added a small utility function to remove leading and trailing " from a toml string value.
Updated the systemconfig parser to use the util function when reading the install_cmd